### PR TITLE
Incorrect sed usage during curl output clean up procedure

### DIFF
--- a/cqcfgls
+++ b/cqcfgls
@@ -73,7 +73,7 @@ _list_configurations()
 
     STATUS=$(${CURLBIN} \
         -s \
-        --write-out "%{http_code}" \
+        --write-out "\n%{http_code}\n" \
         -u "${AUTH}" \
         -H "${REFERERHEADER}" \
         "${URL}")
@@ -92,7 +92,7 @@ _list_configurations()
         exit ${EXITCODE2}
     fi
 
-    STATUS=$(echo "${STATUS}" | sed -r 's#[0-9]{3}$##')
+    STATUS=$(echo "${STATUS}" | ${SEDX} '$d')
     CLEARED_STATUS2=$(echo "${STATUS}" | grep '^PID' | ${SEDX} 's#&nbsp;# #g' \
         | ${SEDX} 's#<br/>##g' | cut -f2- -d '=' \
         | ${SEDX} 's#^[ ]+##; s#[ ]+$##')


### PR DESCRIPTION
Hey Arek,

it seems that `cqcfgls` has an issue that makes the output slightly wrong. 

This bug was pretty hard to track, as at first glance all the entries look perfectly fine and in most cases it was close to impossible to realize that something is displayed incorrectly. To be even worse I thought that something has to be wrong with either my code (test suite for one of my Chef cookbooks, 9 out of 10 test runs ended successfully) or CQ/AEM itself. Because of that non-deterministic behaviour I stuck to this opinion for quite a long time, until I decided to check the code of `cqcfgls` and I think I found the root cause of the problem.

So, what is actually wrong with `cqcfgls`? In `_list_configurations()` function you merge the output of `/system/console/components.json` and `/system/console/config/Configurations.nfo`. 
The first one is a JSON file that is returned as a single line of text. When `curl` is invoked you append HTTP status code to this single line, which eventually makes the output like this `<long_json_line><http_status_code>` (`STATUS` variable). Later on you pass this on to `sed` which removes the very last 3 digits (HTTP status code to be precise, `${SEDX} 's#[0-9]{3}$##'`). It works perfectly fine and I have absolutely no remarks when it comes to this part.
The second part though is slightly different. The output of GET request to `/system/console/config/Configurations.nfo` is not returned as a single line of text, but as a regular multi-line file. Regardless of that in current shape `cqcfgls` is processed the same way when it comes to `curl` and `sed` usage. The problem is `sed -r 's#[0-9]{3}$##'` removes last 3 digits from _every_ line that matches to this pattern.

I decided to compare how `STATUS` variable looks like before and after `sed` processing and here's the diff (I intentionally removed some lines, as originally it was over 200 lines long):
```
35,36c35,36
< &nbsp;&nbsp;cache.size&nbsp;=&nbsp;100
< &nbsp;&nbsp;cache.ttl&nbsp;=&nbsp;100000
---
> &nbsp;&nbsp;cache.size&nbsp;=&nbsp;
> &nbsp;&nbsp;cache.ttl&nbsp;=&nbsp;100
49c49
< &nbsp;&nbsp;maxTotalAttachmentSize&nbsp;=&nbsp;104857600
---
> &nbsp;&nbsp;maxTotalAttachmentSize&nbsp;=&nbsp;104857
61c61
< &nbsp;&nbsp;maxTotalAttachmentSize&nbsp;=&nbsp;104857600
---
> &nbsp;&nbsp;maxTotalAttachmentSize&nbsp;=&nbsp;104857
84c84
< &nbsp;&nbsp;oauth.client.id&nbsp;=&nbsp;324926940878880
---
> &nbsp;&nbsp;oauth.client.id&nbsp;=&nbsp;324926940878
86c86
< &nbsp;&nbsp;oauth.config.id&nbsp;=&nbsp;cb4da2dbc7a22ad11bacb8e39ef92929
---
> &nbsp;&nbsp;oauth.config.id&nbsp;=&nbsp;cb4da2dbc7a22ad11bacb8e39ef92
153c153
< &nbsp;&nbsp;com.adobe.granite.ocs.cloud-delete.sleep&nbsp;=&nbsp;5000
---
<removed/>
---
> PID&nbsp;=&nbsp;org.apache.sling.jcr.resourcesecurity.impl.ResourceAccessGateFactory.c65fdeea-de49-4931-b3e7-274c39f7e
934c934
< &nbsp;&nbsp;service.pid&nbsp;=&nbsp;org.apache.sling.jcr.resourcesecurity.impl.ResourceAccessGateFactory.c65fdeea-de49-4931-b3e7-274c39f7e579
---
> &nbsp;&nbsp;service.pid&nbsp;=&nbsp;org.apache.sling.jcr.resourcesecurity.impl.ResourceAccessGateFactory.c65fdeea-de49-4931-b3e7-274c39f7e
983c983
< &nbsp;&nbsp;json.maximumresults&nbsp;=&nbsp;1000
---
> &nbsp;&nbsp;json.maximumresults&nbsp;=&nbsp;1
989c989
< &nbsp;&nbsp;servletresolver.cacheSize&nbsp;=&nbsp;1000
---
> &nbsp;&nbsp;servletresolver.cacheSize&nbsp;=&nbsp;1
995d994
< 200
\ No newline at end of file
```
As you can see a lot of things were modified. 

Why I think it was hard to find this? `cqcfgls` cares only about PID lines, as the purpose of it is to list all available OSGi configurations. So despite of the fact there were amendments in over 200 lines in raw form, the final output contained only 12 incorrect PIDs on my test AEM instance (557 items in total were displayed). In my case only PIDs with UUID names were affected. 
Moreover this bug, as said in the beginning, used to occur in a pretty non-deterministic manner and majority (if not all) of these happened on my CI environment that spins up brand new VM, runs Chef inside followed by a number of test suites and destroys the VM, so I had no access to that environment when the process was over. When I click 'Build' after such failure the bug was gone. And, as you can imagine, I was not able to reproduce it on my laptop either.

How do I found that? One of my Chef cookbooks creates a couple of OSGi configurations. All the actions in the cookbook have a matching test suite. One of these configurations was created using factory OSGi configuration and I expected that after provisioning its state should be as follows:

* only one factory config instance should be present
* configuration of it should match certain criteria (i.e. `key1 == 100`, `key2 == 'string2'`, etc)

To verify first requirement I did the following thing:
```ruby
regex_suffix = '\.[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}'
list.scan(/#{factory_pid}#{regex_suffix}/)
```
In above code snippet `factory_pid` was the PID I was looking for and `list` is the output of `cqcfgls` command. All in all I was looking for the number of occurrences of a given factory PID.

Recently I finally managed to get the same error locally. The output of my test was as follows:
```
Failures:
       
         1) AEM Author: <my_factory_config> is configured correctly
            Failure/Error: )
              
              expected: "1000"
                   got: ""
              
              (compared using ==)
              
            # /tmp/busser/suites/serverspec/author_conf_spec.rb:38:in `block (2 levels) in <top (required)>'
       
         2) AEM Author: <my_factory_config> has just a single instance
            Failure/Error: ).length
              
              expected: 1
                   got: 0
              
              (compared using ==)
              
            # /tmp/busser/suites/serverspec/author_conf_spec.rb:72:in `block (2 levels) in <top (required)>'
```

When I logged into OSGi console, the configuration was in place and had valid UUID. `cqcfgls` reported that there's a  `my.factory.config.43d23f6f-e5e7-4bc2-82da-72b2b1664` config (3 last characters of UUID are missing), but in fact it was `my.factory.config.43d23f6f-e5e7-4bc2-82da-72b2b1664787`.

Why this problem occurred only from time time? UUID is generated and appended to each OSGi config that is created from a factory PID. UUID is always a string that has 5 groups separated by hyphens (8-4-4-4-12 characters in each group). However there's no guarantee that the very last 3 characters of the last UUID group will always be numbers, hence the non-deterministic behaviour.

In this PR I modified the way `/system/console/config/Configurations.nfo` is processed. HTTP status code is appended as a new line to the raw output and later on, when this info is not needed any more, this line is simply removed. By the way, I've also updated how `sed` is referenced, previously it was just `sed` instead of `${SEDX}`.

That's a pretty long explanation as for the PR that changes just 2 lines :)