### PR TITLE
URL encoding bugfix

### DIFF
--- a/cqapi
+++ b/cqapi
@@ -343,6 +343,12 @@ _urlencode()
         | sed 's#@#%40#g'      \
         | sed 's#\[#%5B#g'     \
         | sed 's#\]#%5D#g'     \
+        | sed 's#\^#%5E#g'     \
+        | sed 's#\##%23#g'     \
+        | sed 's#{#%7B#g'     \
+        | sed 's#}#%7D#g'     \
+        | sed 's#<#%3C#g'     \
+        | sed 's#>#%3E#g'
     )
     echo "${output}"
     exit

--- a/cqcfg
+++ b/cqcfg
@@ -232,8 +232,7 @@ _modify_configuration()
     for operation in ${operations}
     do
         propname=$(echo "${operation}" | cut -f1 -d '=')
-        propvalue=$(echo "${operation}" | cut -f2- -d '=' |\
-            sed 's# #%20#g' | "${API}" -f)
+        propvalue=$(echo "${operation}" | cut -f2- -d '=' | "${API}" -f)
 
         prop_original_value=$(echo "${operation}" | cut -f2- -d '=' |\
             sed 's#%20# #g')


### PR DESCRIPTION
Hey,

I encountered an odd issue while I was testing my Chef provider for OSGi configurations. I tried to amend  `com.day.cq.rewriter.linkchecker.impl.LinkCheckerImpl`, but it turned out it was not possible.

This is its default configuration:
```
PID          com.day.cq.rewriter.linkchecker.impl.LinkCheckerImpl
TITLE        Day CQ Link Checker Service
DESCRIPTION  Performs asynchronous checking of external links.
BUNDLE       Day Communique 5 Rewriter (com.day.cq.cq-rewriter), Version 5.6.4


ID                                   VALUE                                                   NAME                          VALUES  DESCRIPTION
scheduler.period                     5                                                       Scheduler Period
scheduler.concurrent                 false                                                   scheduler.concurrent.name
service.bad_link_tolerance_interval  48                                                      Bad Link Tolerance Interval
service.check_override_patterns      ["^system/"]                                            Link Check Override Patterns
service.cache_broken_internal_links  false                                                   Cache Broken Internal Links
service.special_link_prefix          ["#","${","<!--","data:","javascript:","mailto:","z:"]  Special Link Prefixes
service.special_link_patterns                                                                Special Link Patterns
```

My provider eventually executes `cqcfg` command like this:

```
/opt/scripts/CQ-Unix-Toolkit/cqcfg \
	-i http://localhost:4502 \
	-u admin \
	-p admin \
	-s "scheduler.period" -v "5" \
	-s "scheduler.concurrent" -v "false" \
	-s "service.bad_link_tolerance_interval" -v "24" \
	-s "service.check_override_patterns" -v "^system/" \
	-s "service.cache_broken_internal_links" -v "false" \
	-s "service.special_link_prefix" -v "#" \
	-s "service.special_link_prefix" -v "${" \
	-s "service.special_link_prefix" -v "<!--" \
	-s "service.special_link_prefix" -v "data:" \
	-s "service.special_link_prefix" -v "javascript:" \
	-s "service.special_link_prefix" -v "mailto:" \
	-s "service.special_link_prefix" -v "z:" \
	-s "service.special_link_patterns" -v "" \
	com.day.cq.rewriter.linkchecker.impl.LinkCheckerImpl
```

Unfortunately I ended with non-zero exit code with the following message:

```
bash: !--": event not found
```

The root cause was quite straightforward - all parameters should be enclosed with single quotes and not the double ones ([reference](http://stackoverflow.com/a/6697781)). I've updated my code, but `cqcfg` was still not working:

```
CURL ERROR 3: URL malformed. The syntax was not correct.
```

I came up with the idea to encode all the values in my ruby code, but it turned out it was a dead end. I eventually discovered that CQ UNIX Toolkit can do that automatically thanks to `_urlencode` function from `cqapi`, so encoding of already encoded values is a bad idea.

All in all I did a comparison of HTTP requests generated by the browser and `cqcfg` command and the difference was as follows:

Browser | cqcfg
----------- | ---------
`service.check_override_patterns=%5Esystem%2F` | `service.check_override_patterns=^system%2F`
`service.special_link_prefix=%23` | `service.special_link_prefix=#`
`service.special_link_prefix=%24%7B` | `service.special_link_prefix=%24{`
`service.special_link_prefix=%3C!--` | `service.special_link_prefix=<%21--`

As you can see some characters were not encoded, so I decided to dig into the `cqcfg` and `cqapi` code.

In this PR:
- new encoding rules were added
- redundant `sed` command from `cqcfg` was removed (more detailed explanation has been placed in [this commit](https://github.com/jwadolowski/CQ-Unix-Toolkit/commit/d000ae819d5913db2b9ffcc011606676037a8546))