### PR TITLE
Wrong percent code for backslash character

### DIFF
--- a/cqapi
+++ b/cqapi
@@ -321,7 +321,7 @@ _urlencode()
         | sed 's#%#%25#g'       \
         | sed 's# #%20#g'       \
         | sed 's#!#%21#g'       \
-        | ${SEDX} 's#\\#%23#g'  \
+        | ${SEDX} 's#\\#%5C#g'  \
         | ${SEDX} 's#\$#%24#g'  \
         | sed 's#&#%26#g'       \
         | sed "s#'#%27#g"       \


### PR DESCRIPTION
Backslash was encoded to `%23` (which decodes to `#`) instead of `%5C`.