### PR TITLE
#24 Better error validation for CRX package manager tools

### DIFF
--- a/cqput
+++ b/cqput
@@ -109,8 +109,12 @@ do
         STATUS=$(echo "${STATUS}" | sed '$d')
         "${API}" -H "${STATUSCODE}"
         EXITCODE2=${?}
-        if [ "${EXITCODE}" -ne 0 -o "${EXITCODE2}" -ne 0 ]
+        INNERHTTPCODE=$(echo "${STATUS}" | xmllint --xpath "string(//status/@code)" -)
+        "${API}" -H "${INNERHTTPCODE}"
+        EXITCODE3=${?}
+        if [ "${EXITCODE}" -ne 0 -o "${EXITCODE2}" -ne 0 -o "${EXITCODE3}" -ne 0 ]
         then
+            echo "${STATUS}" >&2
             bad=1
         else
             echo "${STATUS}"

--- a/cqrun
+++ b/cqrun
@@ -114,6 +114,9 @@ STATUSCODE=$(echo "${STATUS}" | tail -n 1)
 "${API}" -H "${STATUSCODE}"
 EXITCODE2=${?}
 STATUS=$(echo "${STATUS}" | sed '$d')
+INNERHTTPCODE=$(echo "${STATUS}" | xmllint --xpath "string(//status/@code)" -)
+"${API}" -H "${INNERHTTPCODE}"
+EXITCODE3=${?}
 echo "${STATUS}"
-exit $((EXITCODE + EXITCODE2))
+exit $((EXITCODE + EXITCODE2 + EXITCODE3))
 


### PR DESCRIPTION
Ensures **cqput** and **cqrun** return without success (`returncode != 0`) when the response from CQ contains inner HTTP code different than `200`.